### PR TITLE
README: Improve documentation for compilation-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -35,4 +35,5 @@ manual intervention, use:
   (add-hook 'occur-mode-hook #'epithet-rename-buffer)
   (add-hook 'shell-mode-hook #'epithet-rename-buffer)
   (add-hook 'compilation-start-hook #'epithet-rename-buffer-ignoring-arguments)
+  (add-hook 'compilation-finish-functions #'epithet-rename-buffer-ignoring-arguments)
 #+end_src


### PR DESCRIPTION
Add a line to README.org showing how to update the buffer's name when
compilation finishes. This is useful because the buffer name includes
the compilation process status:

- `*compilation: [Running] …`
- `*compilation: [Finished] …`